### PR TITLE
[BUG] compute vms aren't removed when teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ ocp4/
 pull-secret.txt
 rhcos-install
 satellite-server-manifest.zip
+qubinode_profile.log

--- a/lib/qubinode_hardware_profile.sh
+++ b/lib/qubinode_hardware_profile.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 
 function collect_system_information() {
-  MANUFACTURER=$(sudo dmidecode --string system-manufacturer)
-  PRODUCTNAME=$(sudo dmidecode --string baseboard-product-name)
-  AVAILABLE_MEMORY=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
-  AVAILABLE_HUMAN_MEMORY=$(free -h | awk '/Mem/ {print $2}')
+    MANUFACTURER=$(sudo dmidecode --string system-manufacturer)
+    PRODUCTNAME=$(sudo dmidecode --string baseboard-product-name)
+    AVAILABLE_MEMORY=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
+    AVAILABLE_HUMAN_MEMORY=$(free -h | awk '/Mem/ {print $2}')
 
 
-  libvirt_pool_name=$(cat playbooks/vars/all.yml | grep libvirt_pool_name: | awk '{print $2}')
-  AVAILABLE_STORAGE=$(sudo virsh pool-list --details | grep "${libvirt_pool_name}" |awk '{print $5*1024}')
-  AVAILABLE_HUMAN_STORAGE=$(sudo virsh pool-list --details | grep "${libvirt_pool_name}" |awk '{print $5,$6}')
+    libvirt_pool_name=$(cat playbooks/vars/all.yml | grep libvirt_pool_name: | awk '{print $2}')
+    AVAILABLE_STORAGE=$(sudo virsh pool-list --details | grep "${libvirt_pool_name}" |awk '{print $5*1024}')
+     AVAILABLE_HUMAN_STORAGE=$(sudo virsh pool-list --details | grep "${libvirt_pool_name}" |awk '{print $5,$6}')
 }
 
 if [[ ! -f qubinode_profile.log ]]; then
-  rm -rf qubinode_profile.log
-  collect_system_information
+    rm -rf qubinode_profile.log
+    collect_system_information
 cat >qubinode_profile.log<<EOF
 Manufacturer: ${MANUFACTURER}
 Product Name: ${PRODUCTNAME}
@@ -34,6 +34,7 @@ CPU INFO
 $(lscpu | egrep 'Model name|Socket|Thread|NUMA|CPU\(s\)')
 EOF
 
+fi
+
 echo "SYSTEM REPORT"
 cat qubinode_profile.log
-fi


### PR DESCRIPTION
**Qubinode Version**  
Qubinode releasev2.2  

**Describe the bug**
running ```./qubinode-installer -p ocp4 -d``` does not delete all the vms.

**To Reproduce**
Run  ```./qubinode-installer -p ocp4 -d```

**Expected behavior**
All ocp4 vms deleted

**Screenshots**
```error: failed to get domain 'compute-0}'
error: Domain not found: no domain with matching name 'compute-0}'

Domain compute-1 destroyed

error: failed to get domain 'compute-1}'
error: Domain not found: no domain with matching name 'compute-1}'```

 

**Hardware Profile infomation**  
Manufacturer: Supermicro
Product Name: X11SDV-8C-TP8F

System Memory
*************
Avaliable Memory: 131495388
Avaliable Human Memory: 125G

Storage Information
*******************
Avaliable Storage: 976282
Avaliable Human Storage: 953.40 GiB

CPU INFO
***************
CPU(s):                16
On-line CPU(s) list:   0-15
Thread(s) per core:    2
Socket(s):             1
NUMA node(s):          1
Model name:            Intel(R) Xeon(R) D-2146NT CPU @ 2.30GHz
NUMA node0 CPU(s):     0-15