### PR TITLE
support for deploying generic RHEL vms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ python-env/
 release.txt
 requirements.txt
 Working/
+.rhel/

--- a/lib/qubinode_kvmhost.sh
+++ b/lib/qubinode_kvmhost.sh
@@ -273,13 +273,13 @@ function qubinode_networking () {
     PTR=$(echo "$NETWORK" | awk -F . '{print $4"."$3"."$2"."$1".in-addr.arpa"}'| sed 's/^[^.]*.//g')
 
     # ask user for their IP network and use the default
-    if cat "${kvm_host_vars_file}"|grep -q changeme.in-addr.arpa
+    if egrep -R changeme.in-addr.arpa "${project_dir}/playbooks/vars/" >/dev/null 2>&1
     then
-        #read -p " ${mag}Enter your IP Network or press${end} ${yel}[ENTER]${end} ${mag}for the default [$NETWORK]: ${end}" network
-        #network=${network:-"${NETWORK}"}
         network="${NETWORK}"
         PTR=$(echo "$NETWORK" | awk -F . '{print $4"."$3"."$2"."$1".in-addr.arpa"}'|sed 's/^[^.]*.//g')
-        sed -i "s/changeme.in-addr.arpa/"$PTR"/g" "${kvm_host_vars_file}"
+        test -f "${kvm_host_vars_file}" && sed -i "s/qubinode_ptr:.*/qubinode_ptr: "$PTR"/g" "${kvm_host_vars_file}"
+        test -f "${project_dir}/playbooks/vars/all.yml" && sed -i "s/qubinode_ptr:.*/qubinode_ptr: "$PTR"/g" "${project_dir}/playbooks/vars/all.yml"
+        test -f "${project_dir}/playbooks/vars/idm.yml" && sed -i "s/changeme.in-addr.arpa/"$PTR"/g" "${project_dir}/playbooks/vars/idm.yml"
     fi
 
     if [ -f "${kvm_host_vars_file}" ]

--- a/lib/qubinode_menu_options.sh
+++ b/lib/qubinode_menu_options.sh
@@ -29,6 +29,7 @@ function qubinode_product_deployment () {
                   openshift4_server_maintenance
               else
                   ASK_SIZE=true
+                  check_for_rhel_qcow_image
                   qubinode_deploy_ocp4
               fi
               ;;
@@ -57,6 +58,14 @@ function qubinode_product_deployment () {
               else
                   echo "Running IdM VM deploy function"
                   qubinode_deploy_idm
+              fi
+              ;;
+          rhel)
+              if [ "A${teardown}" == "Atrue" ]
+              then
+                  echo "Tear Down RHEL VM"
+              else
+                  qubinode_deploy_rhel
               fi
               ;;
           kvmhost)

--- a/lib/qubinode_menu_options.sh
+++ b/lib/qubinode_menu_options.sh
@@ -63,7 +63,7 @@ function qubinode_product_deployment () {
           rhel)
               if [ "A${teardown}" == "Atrue" ]
               then
-                  echo "Tear Down RHEL VM"
+                  qubinode_rhel_teardown
               else
                   qubinode_deploy_rhel
               fi

--- a/lib/qubinode_menu_welcome.sh
+++ b/lib/qubinode_menu_welcome.sh
@@ -46,6 +46,7 @@ display_openshift_msg_ocp4 () {
     elif [ "A${result}" == "AContinue" ]
     then
         ASK_SIZE=false
+        check_for_rhel_qcow_image
         qubinode_deploy_ocp4
     else
         print "%s\n" " ${red}Unknown issue, please run the installer again${end}"
@@ -74,12 +75,15 @@ display_other_options () {
         echo "Not implemented yet!"
     elif [ "A${result}" == "ATower" ]
     then
+        check_for_rhel_qcow_image
         qubinode_deploy_tower
     elif [ "A${result}" == "ASatellite" ]
     then
+        check_for_rhel_qcow_image
         qubinode_deploy_satellite
     elif [ "A${result}" == "AIdM" ]
     then
+        check_for_rhel_qcow_image
         qubinode_deploy_idm
     else
         echo "Unknown issue, please run the installer again"

--- a/lib/qubinode_openshift_sizing_menu.sh
+++ b/lib/qubinode_openshift_sizing_menu.sh
@@ -257,36 +257,36 @@ function ocp4_menu(){
         user_choose_ocp4_profile
 
         printf "%s\n" ""
-        confirm " ${cyn}Would you like a customize deployment? yes/no${end}"
-        echo    # (optional) move to a new line
-        if [ "A${response}" == "Ayes" ]
-        then
-            openshift4_custom_desc
-            #user_choose_ocp4_profile
-        elif [ "A${response}" == "Ano" ]
-        then
-            case $INSTALLTYPE in
-            minimal)
-                ocp_size=minimal
-                continue_with_selected_install
-                ;;
-            standard)
-                ocp_size=standard
-                continue_with_selected_install
-                ;;
-            custom)
-                ocp_size=custom
-                continue_with_selected_install
-                ;;
-            *) exit 0;;
-            esac
-        else
-            echo "Option not met"
+        #confirm " ${cyn}Would you like a customize deployment? yes/no${end}"
+        #echo    # (optional) move to a new line
+        #if [ "A${response}" == "Ayes" ]
+        #then
+        #    openshift4_custom_desc
+        #    #user_choose_ocp4_profile
+        #elif [ "A${response}" == "Ano" ]
+        #then
+        #    case $INSTALLTYPE in
+        #    minimal)
+        #        ocp_size=minimal
+        #        continue_with_selected_install
+        #        ;;
+        #    standard)
+        #        ocp_size=standard
+        #        continue_with_selected_install
+        #        ;;
+        #    custom)
+        #        ocp_size=custom
+        #        continue_with_selected_install
+        #        ;;
+        #    *) exit 0;;
+        #    esac
+        #else
+        #    break
             #while true
             #do
             #    user_choose_ocp4_profile
             #done
-        fi
+        #fi
     fi
 }
 

--- a/lib/qubinode_rhel.sh
+++ b/lib/qubinode_rhel.sh
@@ -132,8 +132,11 @@ function qubinode_deploy_rhel () {
 
 function run_rhel_deployment () {
     local rhel_server_hostname=$1
+    sed -i "s/rhel_name:.*/rhel_name: "$rhel_server_hostname"/g" "${rhel_vars_file}"
+    qubinode_networking
     qcow_image_file="/var/lib/libvirt/images/${rhel_server_hostname}_vda.qcow2"
-    if ! sudo virsh list --all |grep -q "${rhel_server_hostname}"
+    #if ! sudo virsh list --all |grep -q "${rhel_server_hostname}"
+    if ! sudo virsh dominfo "${rhel_server_hostname}" >/dev/null 2>&1
     then
         PLAYBOOK_STATUS=0
         sudo test -f $qcow_image_file && sudo rm -f $qcow_image_file 
@@ -152,7 +155,7 @@ function run_rhel_deployment () {
     fi
 
     # return the status of the playbook run
-    exit $PLAYBOOK_STATUS
+    #return $PLAYBOOK_STATUS
 }
 
 

--- a/lib/qubinode_rhel.sh
+++ b/lib/qubinode_rhel.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+function qubinode_deploy_rhel () {
+    setup_variables
+    RHEL_VM_PLAY="${project_dir}/playbooks/rhel.yml"
+    rhel_vars_file="${project_dir}/playbooks/vars/rhel.yml"
+
+    product_in_use=rhel
+    prefix=$(awk '/instance_prefix/ {print $2;exit}' "${vars_file}")
+    suffix=rhel
+
+    # Generate a random id that's not already is use for the cattle vms
+    while true
+    do
+        instance_id=$((1 + RANDOM % 4096))
+        if ! sudo virsh list --all | grep $instance_id
+        then
+            break
+        fi
+    done
+
+    # Check for user provided variables
+    for var in "${product_options[@]}"
+    do
+        local $var
+    done
+
+    if [ "A${name}" != "A" ]
+    then
+        rhel_server_hostname="${prefix}-${name}"
+    else
+        rhel_server_hostname="${prefix}-${suffix}${release}-${instance_id}"
+    fi
+
+    if [ "A${release}" != "A" ]
+    then
+        rhel_release="$release"
+    else
+        rhel_release=7
+    fi
+
+    # Get instance size
+    if [ "A${size}" != "A" ]
+    then
+        if [ "A${size}" == "Asmall" ]
+        then
+            echo "Setting VM size to small"
+            vcpu=1
+            memory=800
+            disk=20G
+        elif [ "A${size}" == "Amedium" ]
+        then
+            echo "Setting VM size to medium"
+            vcpu=2
+            memory=2048
+            disk=60G
+        elif [ "A${size}" == "Alarge" ]
+        then
+            echo "Setting VM size to large"
+            vcpu=4
+            memory=8192
+            disk=200G
+        else
+            echo "using default size"
+       fi
+    else
+        echo "Setting VM size to small"
+        vcpu=1
+        memory=800
+        disk=20G
+    fi
+
+    # Default RHEL release to deploy
+    qcow_image="rhel-server-7.7-update-2-x86_64-kvm.qcow2"
+    if [ "A${relese}" == "A7" ]
+    then
+        qcow_image="rhel-server-7.7-update-2-x86_64-kvm.qcow2"
+    elif [ "A${relese}" == "A8" ]
+    then
+        qcow_image="rhel-server-7.7-update-2-x86_64-kvm.qcow2"
+    else
+        qcow_image="rhel-server-7.7-update-2-x86_64-kvm.qcow2"
+    fi
+
+
+    rhel_server_fqdn="${rhel_server_hostname}.${domain}"
+
+    # Ensure rhel vars file is active
+    if [ ! -f "${rhel_vars_file}" ]
+    then
+        cp "${project_dir}/samples/rhel.yml" "${rhel_vars_file}"
+    fi
+
+    sed -i "s/rhel_name:.*/rhel_name: "$rhel_server_hostname"/g" "${rhel_vars_file}"
+    sed -i "s/rhel_vcpu:.*/rhel_vcpu: "$vcpu"/g" "${rhel_vars_file}"
+    sed -i "s/rhel_memory:.*/rhel_memory: "$memory"/g" "${rhel_vars_file}"
+    sed -i "s/rhel_root_disk_size:.*/rhel_root_disk_size: "$disk"/g" "${rhel_vars_file}"
+    sed -i "s/cloud_init_vm_image:.*/cloud_init_vm_image: "$qcow_image"/g" "${rhel_vars_file}"
+    echo $rhel_server_hostname
+    echo $rhel_server_fqdn
+
+    qcow_image_file="/var/lib/libvirt/images/${rhel_server_hostname}_vda.qcow2"
+    if ! sudo virsh list --all |grep -q "${rhel_server_hostname}"
+    then
+        sudo test -f $qcow_image_file && rm -f $qcow_image_file 
+        echo "Deploying $rhel_server_hostname"
+        ansible-playbook "${RHEL_VM_PLAY}" || exit $?
+    fi
+
+}
+
+
+#function qubinode_teardown_rhel () {
+#     IDM_PLAY_CLEANUP="${project_dir}/playbooks/rhel_server_cleanup.yml"
+#     if sudo virsh list --all |grep -q "${rhel_server_hostname}"
+#     then
+#         echo "Remove IdM VM"
+#         ansible-playbook "${RHEL_VM_PLAY}" --extra-vars "vm_teardown=true" || exit $?
+#     fi
+#     echo "Ensure IdM server deployment is cleaned up"
+#     ansible-playbook "${IDM_PLAY_CLEANUP}" || exit $?
+#
+#     printf "\n\n*************************\n"
+#     printf "* IdM server VM deleted *\n"
+#     printf "*************************\n\n"
+#}
+#
+#function qubinode_deploy_rhel_vm () {
+#    if grep deploy_rhel_server "${rhel_vars_file}" | grep -q yes
+#    then
+#        qubinode_vm_deployment_precheck
+#        isIdMrunning
+#
+#        IDM_PLAY_CLEANUP="${project_dir}/playbooks/rhel_server_cleanup.yml"
+#        SET_IDM_STATIC_IP=$(awk '/rhel_check_static_ip/ {print $2; exit}' "${rhel_vars_file}"| tr -d '"')
+#
+#        if [ "A${rhel_running}" == "Afalse" ]
+#        then
+#            echo "running playbook ${RHEL_VM_PLAY}"
+#            if [ "A${SET_IDM_STATIC_IP}" == "Ayes" ]
+#            then
+#                echo "Deploy with custom IP"
+#                rhel_server_ip=$(awk '/rhel_server_ip:/ {print $2}' "${rhel_vars_file}")
+#                ansible-playbook "${RHEL_VM_PLAY}" --extra-vars "vm_ipaddress=${rhel_server_ip}"|| exit $?
+#             else
+#                 echo "Deploy without custom IP"
+#                 ansible-playbook "${RHEL_VM_PLAY}" || exit $?
+#             fi
+#         fi
+#     fi
+#}
+#

--- a/playbooks/requirements.yml
+++ b/playbooks/requirements.yml
@@ -1,5 +1,5 @@
 - src: https://github.com/Qubinode/deploy-kvm-vm.git
-  version: v1.0.0
+  version: dev
 
 - src: https://github.com/Qubinode/qubinode_kvmhost_setup.git
   version: dev

--- a/playbooks/rhel.yml
+++ b/playbooks/rhel.yml
@@ -8,6 +8,7 @@
     - vars/kvm_host.yml
     - vars/vault.yml
     - vars/rhel.yml
+    - vars/idm.yml
   vars:
     vm_name: "{{ rhel_server_vm.rhel_name }}"
     vm_cpu: "{{ rhel_server_vm.rhel_vcpu }}"
@@ -21,7 +22,50 @@
     enable: "{{ rhel_server_vm.rhel_enable }}"
     current_vm_ip: "{{ hostvars[vm_name]['ansible_host'] }}"
 
+  environment:
+    IPA_HOST: "{{ ipa_host }}"
+    IPA_USER: "{{ idm_admin_user }}"
+    IPA_PASS: "{{ idm_admin_pwd }}"
+    IPA_TIMEOUT: 40
+
   tasks:
     - name: Create KVM VM for RHEL Server
       include_role:
         name: deploy-kvm-vm
+
+    - name: set dns record state
+      set_fact:
+        dns_a_result: "none"
+        dns_ptr_result: "none"
+        record_state: "{{ 'absent' if vm_teardown|bool else 'present' }}"
+      tags: create_dns_records
+
+    - name: Create/Delete {{ vm_name }} A Records
+      ipa_dnsrecord:
+        zone_name: "{{ domain }}"
+        record_name: "{{ hostvars[vm_name].inventory_hostname }}"
+        record_type: A
+        #record_ttl: 300
+        record_value: "{{ hostvars[vm_name].ansible_host }}"
+        state: "{{ record_state }}"
+        validate_certs: no
+      tags: create_dns_records
+
+    - name: Create/Delete {{ vm_name }} PTR Records
+      ipa_dnsrecord:
+        zone_name: "{{ qubinode_ptr }}"
+        record_name: "{{ hostvars[vm_name].ansible_host.split('.')[3:4] | join('.') }}"
+        record_type: PTR
+        #record_ttl: 300
+        record_value: "{{ hostvars[vm_name].inventory_hostname }}.{{ domain }}."
+        state: "{{ record_state }}"
+        validate_certs: no
+      tags: create_dns_records
+
+    - name: REMOVE|ensure {{ vm_name }} is removed from inventory
+      lineinfile:
+        path: "{{ inventory_file }}"
+        regexp: "^{{ vm_name }}"
+        state: absent
+      when: vm_teardown|bool
+

--- a/playbooks/rhel.yml
+++ b/playbooks/rhel.yml
@@ -1,0 +1,27 @@
+---
+- name: Deploy RHEL VM
+  hosts: localhost
+  become: yes
+  gather_facts: yes
+  vars_files:
+    - vars/all.yml
+    - vars/kvm_host.yml
+    - vars/vault.yml
+    - vars/rhel.yml
+  vars:
+    vm_name: "{{ rhel_server_vm.rhel_name }}"
+    vm_cpu: "{{ rhel_server_vm.rhel_vcpu }}"
+    vm_memory: "{{ rhel_server_vm.rhel_memory }}"
+    vm_root_disk_size: "{{ rhel_server_vm.rhel_root_disk_size }}"
+    vm_teardown: "{{ rhel_server_vm.rhel_teardown }}"
+    vm_recreate: "{{ rhel_server_vm.rhel_recreate }}"
+    vm_domain: "{{ domain }}"
+    inventory_group: "{{ rhel_server_vm.rhel_group }}"
+    extra_storage: "{{ rhel_server_vm.rhel_extra_storage }}"
+    enable: "{{ rhel_server_vm.rhel_enable }}"
+    current_vm_ip: "{{ hostvars[vm_name]['ansible_host'] }}"
+
+  tasks:
+    - name: Create KVM VM for RHEL Server
+      include_role:
+        name: deploy-kvm-vm

--- a/qubinode-installer
+++ b/qubinode-installer
@@ -84,6 +84,7 @@ source "${project_dir}/lib/qubinode_ocp4.sh"
 source "${project_dir}/lib/qubinode_openshift3_powermgt.sh"
 source "${project_dir}/lib/qubinode_satellite.sh"
 source "${project_dir}/lib/qubinode_tower.sh"
+source "${project_dir}/lib/qubinode_rhel.sh"
 
 
 # Exit if this is executed as the root user
@@ -103,6 +104,7 @@ do
     case $opt in
         a) check_args;
            full_deploy=true
+           product_options+=("$OPTARG")
            ;;
         c) check_args
            check=true
@@ -153,7 +155,6 @@ then
     qubinode_maintenance_options
 elif [ "A${qubinode_product}" == "Atrue" ]
 then
-    check_for_rhel_qcow_image
     qubinode_product_deployment $qubinode_product_opt
 else
     display_help

--- a/samples/ocp4.yml
+++ b/samples/ocp4.yml
@@ -16,17 +16,14 @@ local_user_account: "{{ admin_user }}"
 local_user_ssh_public_key: "/home/{{ local_user_account }}/.ssh/id_rsa.pub"
 ssh_ocp4_public_key: "{{ lookup('file', local_user_ssh_public_key) }}"
 
-# deploy NFS persistent storage
-configure_nfs_storage: yes
-
-# set NFS as the default persistent storage
-set_as_default: true
-
-# Defaults for NFS Provisioner role
-provision_nfs_server: true
+########################
+# NFS Persistent Storage
+configure_nfs_storage: yes  # set to no to skip deploying nfs storage
+set_as_default: true        # set NFS as the default persistent storage
+provision_nfs_server: true  # set to true to setup a nfs server
 nfs_server_directory_path: /export
 nfs_server_ip:  "{{ kvm_host_ip }}"
-provision_nfs_provisoner: true
+provision_nfs_provisoner: true      # deploys the nfs provision
 project_namespace: nfs-provisioner
 
 # deploy OCS persistent storage
@@ -37,14 +34,12 @@ configure_local_storage: no
 localstorage_version: "{{ major_version }}"
 localstorage_filesystem: yes
 localstorage_block: no
-localstorage_mount_path: /dev/vdc
+localstorage_block_disk: /dev/vdc
+localstorage_fs_disk: /dev/vdc
 
 # configure OCP register
 configure_registry: true
 registry_pvc_size: 100Gi
-
-# TODO: futture implementation
-ocp_register_storage: nfs   # options: ocs, nfs
 
 # DNS & IdM info
 internal_domain_name: "{{ domain }}"

--- a/samples/rhel.yml
+++ b/samples/rhel.yml
@@ -17,3 +17,6 @@ rhel_server_vm:
     rhel_enable: true
 
 cloud_init_vm_image: "rhel-server-7.6-x86_64-kvm.qcow2"
+rhel_release: 8
+rhel_8_hash:
+rhel_7_hash:

--- a/samples/rhel.yml
+++ b/samples/rhel.yml
@@ -1,0 +1,19 @@
+################
+# RHEL Server  #
+################
+
+# Dns server VM attributes
+rhel_server_vm:
+    rhel_name: ""
+    rhel_vcpu: 1
+    rhel_memory: 800
+    rhel_root_disk_size: 20G
+    rhel_teardown: false
+    rhel_recreate: false
+    rhel_group: rhel
+    rhel_extra_storage:
+      - size: ""
+        enable: false
+    rhel_enable: true
+
+cloud_init_vm_image: "rhel-server-7.6-x86_64-kvm.qcow2"


### PR DESCRIPTION
```
# Deploy RHEL 8 cattle VM
./qubinode-installer -p rhel -a release=8

# Deploy RHEL 7 cattle VM
./qubinode-installer -p rhel -a release=7

# Deploy a large rhel 8 VM - other options are small, medium, large
./qubinode-installer -p rhel -a release=8 -a size=large 

# Deploy a pet VM - without the release=, RHEL7 will be deployed by default
/qubinode-installer -p rhel -a -a size=medium -a name=webserver

# Deploy 10 RHEL7 small vms
./qubinode-installer -p rhel -a qty=10

# Deploy 4 RHEL8 medium VMS called webserver
./qubinode-installer -p rhel -a qty=5 -a name=webserver -a release=8

# Deleting a VM requires its name and the -d argument
./qubinode-installer -p rhel -a name=qbn-webserver2  -d
```